### PR TITLE
Pathplanner NamedCommands

### DIFF
--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -25,6 +25,11 @@ class RobotContainer:
         NamedCommands.registerCommand("elevatorUp", InstantCommand(lambda: self.elevator.setStage(0)))
         NamedCommands.registerCommand("elevatorMid", InstantCommand(lambda: self.elevator.setStage(1)))
         NamedCommands.registerCommand("elevatorBottom", InstantCommand(lambda: self.elevator.setStage(2)))
+
+        ## Intake
+        NamedCommands.registerCommand("intakeConsume", InstantCommand(lambda: self.intake.consume()))
+        NamedCommands.registerCommand("intakeDisencumber", InstantCommand(lambda: self.intake.disencumber()))
+        NamedCommands.registerCommand("intakeStop", InstantCommand(lambda: self.intake.hold()))
         
         """Sendables!!!"""
         self.start_chooser = SendableChooser()

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -29,6 +29,14 @@ class Intake(Subsystem):
         self.pivotMotor.set_control(phoenix6.controls.MotionMagicDutyCycle(IntakeConstants.PIVOTPOS[self.pivotIndex]))
 
     #####[[ PIVOT FUNCTIONS ]]#####
+    def pivotDown(self) -> None:
+        self.pivotIndex = 0
+
+    def pivotHold(self) -> None:
+        self.pivotIndex = 1
+
+    def pivotAmp(self) -> None:
+        self.pivotIndex = 2
             
     def pivotCycle(self) -> None: #set motor position to something specific
         self.pivotIndex = (self.pivotIndex + 1) % 3


### PR DESCRIPTION
While there's 6 currently, I think we may be able to squash these into 3 modes: Grab, Lock, and Score. For now, this will work.