### PR TITLE
Protect the pivot gearbox from excess torque

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -29,6 +29,7 @@ class IntakeConstants:
     INTAKESPEED = 1
 
 class PivotConstants:
+    CURRENTSUPPLYLIMIT = 20  # Must not over-torque the gearbox
     MM_ACCELERATION = 4
     MM_CRUISE_VEL = 4
     STOWPOS = 0


### PR DESCRIPTION
The pivot gearbox failed at Stemnasium on 4/1/24. On possible source of failure is excess torque. The 50:1 Versaplanetary gear ratio exceeds the rating table for the Falcon 500 motor. A supply current limit will help to prevent excess torque. This change only defines a new constant.

Proposed next steps:

1.   Determine the max normal load current required by the pivot under normal conditions (with and without a game piece).
2.   Adjust current limit to be 50% to 100% greater than the maximum normal load current but do not exceed 35 A.
3.   Add the current limit to the Pivot subsystem.